### PR TITLE
fix(chat): ignore terminal events for stale realtime responses (#9)

### DIFF
--- a/src/lib/LiveChat.svelte
+++ b/src/lib/LiveChat.svelte
@@ -11,6 +11,7 @@
 		type ChatMessage
 	} from './stores/sessionStore';
 	import { repoStore } from './stores/repoStore';
+	import { shouldClearResponseState } from './realtimeResponseState';
 	import { goto } from '$app/navigation';
 
 	// Accept repository as a prop
@@ -392,9 +393,16 @@
 							}
 						}
 						break;
-					case 'response.done':
+					case 'response.done': {
 						// Response completely finished
 						console.log('Response done:', data.response?.id);
+						// A terminal event for an older (e.g. cancelled) response can arrive
+						// after `response.created` for the current one. Clearing state then
+						// would drop every subsequent delta and the user would see no reply.
+						if (!shouldClearResponseState(data.response?.id, currentResponseId)) {
+							console.log('Ignoring stale response.done for', data.response?.id);
+							break;
+						}
 						processingResponse = false;
 						currentResponseId = null;
 
@@ -410,14 +418,22 @@
 							goto(`/c/${$currentSession.id}`, { replaceState: true });
 						}
 						break;
+					}
 
-					case 'response.cancelled':
+					case 'response.cancelled': {
 						// Response was cancelled
 						console.log('Response cancelled:', data.response?.id);
+						// Ignore cancellations for responses we are no longer tracking, so a
+						// late ack cannot silence (or cut the audio of) a newer response.
+						if (!shouldClearResponseState(data.response?.id, currentResponseId)) {
+							console.log('Ignoring stale response.cancelled for', data.response?.id);
+							break;
+						}
 						processingResponse = false;
 						currentResponseId = null;
 						cancelCurrentAudio();
 						break;
+					}
 
 					case 'response.audio.done':
 						// Audio stream is complete, let the queue finish naturally

--- a/src/lib/realtimeResponseState.spec.ts
+++ b/src/lib/realtimeResponseState.spec.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { shouldClearResponseState } from './realtimeResponseState';
+
+describe('shouldClearResponseState', () => {
+	it('clears when the terminal event belongs to the tracked response', () => {
+		expect(shouldClearResponseState('resp_b', 'resp_b')).toBe(true);
+	});
+
+	it('does not clear when a stale response terminates after a newer one started', () => {
+		// resp_a was cancelled, resp_b is now streaming: resp_a's `response.done`
+		// must not wipe out resp_b's id.
+		expect(shouldClearResponseState('resp_a', 'resp_b')).toBe(false);
+	});
+
+	it('clears when nothing is being tracked', () => {
+		expect(shouldClearResponseState('resp_a', null)).toBe(true);
+	});
+
+	it('clears for untagged terminal events so the client cannot get stuck', () => {
+		expect(shouldClearResponseState(undefined, 'resp_b')).toBe(true);
+		expect(shouldClearResponseState(null, 'resp_b')).toBe(true);
+	});
+
+	it('keeps deltas for the new response addressable after a stale terminal event', () => {
+		// Regression for issue #9: a text message sent while a response is in
+		// flight produced no reply at all.
+		let currentResponseId: string | null = null;
+		let processingResponse = false;
+
+		const onResponseCreated = (id: string) => {
+			currentResponseId = id;
+			processingResponse = true;
+		};
+		const onResponseTerminal = (id: string | null | undefined) => {
+			if (!shouldClearResponseState(id, currentResponseId)) return;
+			currentResponseId = null;
+			processingResponse = false;
+		};
+
+		onResponseCreated('resp_a'); // first response starts
+		onResponseCreated('resp_b'); // user sends text; resp_a cancelled, resp_b starts
+		onResponseTerminal('resp_a'); // late terminal event for the cancelled response
+
+		expect(currentResponseId).toBe('resp_b');
+		expect(processingResponse).toBe(true);
+
+		onResponseTerminal('resp_b');
+
+		expect(currentResponseId).toBe(null);
+		expect(processingResponse).toBe(false);
+	});
+});

--- a/src/lib/realtimeResponseState.ts
+++ b/src/lib/realtimeResponseState.ts
@@ -1,0 +1,38 @@
+/**
+ * Helpers for tracking which OpenAI Realtime response the client is currently
+ * streaming.
+ *
+ * The client filters streaming deltas with `data.response_id === currentResponseId`.
+ * That filter is only correct if `currentResponseId` is cleared by the terminal
+ * event (`response.done` / `response.cancelled`) belonging to the *same* response.
+ *
+ * When a text message is sent while an earlier response is still in flight, the
+ * client cancels the old response and immediately requests a new one. The
+ * terminal event for the cancelled response can arrive *after* `response.created`
+ * for the new one. Clearing state unconditionally at that point wipes out the new
+ * response id, so every subsequent delta is filtered out and the user sees no
+ * reply at all — with no error shown.
+ */
+
+/**
+ * Decide whether a terminal response event should clear the tracked response state.
+ *
+ * Returns `false` only when the event is provably about a different (stale)
+ * response than the one currently being tracked.
+ *
+ * @param eventResponseId `response.id` carried by the terminal event, if any.
+ * @param currentResponseId The response id the client is currently tracking.
+ */
+export function shouldClearResponseState(
+	eventResponseId: string | null | undefined,
+	currentResponseId: string | null
+): boolean {
+	// Nothing is being tracked, so clearing is a no-op and always safe.
+	if (currentResponseId === null) return true;
+
+	// Untagged terminal event (e.g. a top-level `error`): we cannot attribute it,
+	// so fall back to clearing rather than risk getting stuck mid-response.
+	if (eventResponseId === null || eventResponseId === undefined) return true;
+
+	return eventResponseId === currentResponseId;
+}


### PR DESCRIPTION
Closes #9.

## The bug

`LiveChat.svelte` filters every streaming delta with `data.response_id === currentResponseId`
(`response.audio.delta`, `response.audio_transcript.delta`, `response.text.delta`).
That filter is only correct while `currentResponseId` tracks the response actually in flight.

`response.done` and `response.cancelled` cleared `currentResponseId` / `processingResponse`
**unconditionally**, without checking which response the event belonged to.

`sendTextMessage()` sends `response.cancel`, waits 300 ms, then sends
`conversation.item.create` + `response.create`. The terminal event for the cancelled
response is not guaranteed to arrive before `response.created` for the new one. When it
arrives after:

1. `response.created` (resp B) → `currentResponseId = 'resp_B'`
2. late `response.done` (resp A) → `currentResponseId = null`, `processingResponse = false`
3. every `response.*.delta` for resp B is now filtered out

The user gets **no reply and no error** — matching the issue's "occasionally, no
acknowledgment or confirmation is received" and its intermittency (it depends on socket
event ordering).

## What changed

- New `src/lib/realtimeResponseState.ts` — a pure `shouldClearResponseState()` helper.
  It returns `false` only when the terminal event is provably about a *different*
  response than the one being tracked. Untagged events (e.g. a top-level `error`) still
  clear, so the client can never get stuck mid-response.
- `src/lib/LiveChat.svelte` — `response.done` and `response.cancelled` now consult that
  helper before clearing state. `response.cancelled` also no longer calls
  `cancelCurrentAudio()` for a response we are no longer tracking, so a late cancel ack
  cannot cut off the audio of a newer response. The `error` handler is unchanged.
- New `src/lib/realtimeResponseState.spec.ts` — 5 tests, including a regression test that
  replays the exact `created(A) → created(B) → done(A)` interleaving.

The helper lives outside the component deliberately so this state machine is unit
testable in the `server` vitest project, i.e. without a browser.

No behaviour change on the happy path: a terminal event whose id matches the tracked
response clears state exactly as before.

## Verification (exact commands and observed output)

There is no CI in `main` today, so the gate below is `package.json`'s scripts plus the
steps defined by the CI workflow proposed in #23.

**Baseline first**, on untouched `8a091b6` — two of these already fail before any change:

```
$ npm run lint
EXIT: 1
[warn] IMPLEMENTATION_COMPLETE.md
[warn] SESSION_DATABASE_INTEGRATION.md
[warn] src/routes/api/sessions/api.test.ts
[warn] Code style issues found in 3 files.

$ npm run check
EXIT: 0
svelte-check found 0 errors and 0 warnings

$ npm run build          # no env vars
EXIT: 1
src/auth.ts (3:9): "GITHUB_CLIENT_ID" is not exported by "virtual:env/static/private"

$ AUTH_SECRET=… GITHUB_CLIENT_ID=… GITHUB_CLIENT_SECRET=… npm run build
EXIT: 0

$ npm test
EXIT: 1   # 0 tests executed — see "Not verified"
```

**With this branch:**

```
$ npm run lint
EXIT: 1
[warn] IMPLEMENTATION_COMPLETE.md
[warn] SESSION_DATABASE_INTEGRATION.md
[warn] src/routes/api/sessions/api.test.ts
```
Identical to baseline — the same three files, none of them touched by this PR. Prettier
reports the two files added here as already formatted.

```
$ npm run check
EXIT: 0
svelte-check found 0 errors and 0 warnings

$ npx vitest run --project server
EXIT: 0
 ↓ src/routes/api/sessions/api.test.ts (13 tests | 13 skipped)
 ✓ src/demo.spec.ts (1 test)
 ✓ src/lib/realtimeResponseState.spec.ts (5 tests)
 ✓ src/lib/stores/themeStore.spec.ts (2 tests)
 ✓ src/lib/stores/sessionStore.spec.ts (7 tests)
 Test Files  4 passed | 1 skipped (5)
      Tests  15 passed | 13 skipped (28)

$ AUTH_SECRET=… GITHUB_CLIENT_ID=… GITHUB_CLIENT_SECRET=… npm run build
EXIT: 0
✓ built in 3.84s

# red/green: helper temporarily stubbed to `return true` (the pre-fix behaviour)
$ npx vitest run --project server src/lib/realtimeResponseState.spec.ts
EXIT: 1
 × does not clear when a stale response terminates after a newer one started
 × keeps deltas for the new response addressable after a stale terminal event
      Tests  2 failed | 3 passed (5)
```

The new tests fail against the old behaviour and pass against the new one.

## Not verified

- **`npm test` in full never ran — at baseline or on this branch.** The `client` vitest
  project needs Playwright Chromium, and the browser cannot be installed on the machine
  used here: extraction hangs at ~628 KB with 0% CPU, reproduced twice (shared cache and
  an isolated `PLAYWRIGHT_BROWSERS_PATH`). Zero tests executed, in both cases — this is
  *not* "browser tests failed". Since there is no baseline for that project either, I can
  neither claim nor disprove a regression there. Mitigating fact: the only browser spec in
  the tree is `src/routes/page.svelte.spec.ts`, and it does not reference `LiveChat`.
- **Not reproduced against a live OpenAI Realtime socket.** The root cause is derived from
  the event-ordering contract and the delta-filtering code, and is covered by a unit test
  of the extracted state machine — not by an end-to-end run with a real API key.
- `npm run lint` is red here and on `main`; this PR neither fixes nor worsens it. Nothing
  in this PR should be read as a green gate.

## Note for #23

`.github/workflows/ci.yml` proposed in #23 runs `npm run lint`. Prettier fails on
`main` **and** on #23's head (`6d05cfe`) on the same three files, so that workflow will be
red on its first run after merge. A `npm run format` commit on those three files fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
